### PR TITLE
missing fix #12 in img_common.hpp file

### DIFF
--- a/includes/img_common.hpp
+++ b/includes/img_common.hpp
@@ -45,7 +45,7 @@
     #endif
 #endif
 
-#pragma pack(push, 1)
+COFF_STRUCT_PACKING
 namespace win
 {
     // Default image architecture


### PR DESCRIPTION
As described in the title, GCC should now no longer produce an error message.